### PR TITLE
Add more predefined icons

### DIFF
--- a/second_sidebar/utils/icons.mjs
+++ b/second_sidebar/utils/icons.mjs
@@ -1,6 +1,8 @@
 const PREDEFINED_ICONS = {
   "about:newtab": "chrome://browser/skin/tab.svg",
-
+  "about:debugging": "chrome://global/skin/icons/developer.svg",
+  "about:config": "chrome://global/skin/icons/settings.svg",
+  "about:processes": "chrome://global/skin/icons/performance.svg",
   "about:settings": "chrome://global/skin/icons/settings.svg",
   "about:preferences": "chrome://global/skin/icons/settings.svg",
   "chrome://browser/content/preferences/preferences.xhtml":


### PR DESCRIPTION
Added predefined icons for the following pages: 

- `about:debugging`
- `about:config`
- `about:processes`