### PR TITLE
Fix sb2-splitter-pinned Visible on Browser Start

### DIFF
--- a/src/second_sidebar/xul/sidebar_splitter_pinned.mjs
+++ b/src/second_sidebar/xul/sidebar_splitter_pinned.mjs
@@ -3,5 +3,6 @@ import { SidebarSplitter } from "./sidebar_splitter.mjs";
 export class SidebarSplitterPinned extends SidebarSplitter {
   constructor() {
     super({ id: "sb2-splitter-pinned" });
+    this.setAttribute("hidden", true);
   }
 }


### PR DESCRIPTION
The splitter is visible by default, meaning it will be visible when starting the browser until the user opens a panel and closes it again, at which point the hidden=true attribute is added. So this adds the attribute at construction.