### PR TITLE
Fix native sidebar appearing inside web panels

### DIFF
--- a/src/second_sidebar/xul/web_panels_browser.mjs
+++ b/src/second_sidebar/xul/web_panels_browser.mjs
@@ -109,10 +109,13 @@ export class WebPanelsBrowser extends Browser {
     const selectors = [
       "#PersonalToolbar",
       "#navigator-toolbox",
+      "#sidebar-container",
       "#sidebar-main",
+      "sidebar-main",
       "#sidebar-launcher-splitter",
       "#sidebar-wrapper",
       "#sidebar-box",
+      "#sidebar-splitter",
       "#context-bookmarkpage",
       "#context-viewsource",
     ];


### PR DESCRIPTION
Firefox's updated browser chrome exposes its native sidebar and vertical tab strip inside FSS web panels. Hide the new sidebar container and `sidebar-main` element in the embedded browser window, together with the separate sidebar splitter that remained visible after hiding the sidebar content.

Retain the legacy selectors for older Firefox layouts. The change is scoped to the embedded document, so the main window's vertical tabs remain visible.

Fixes #189
Fixes #191

Validation:
- Firefox 154.0.1 on Windows 11 with fx-autoconfig: startup passed with no FSS/loader errors; all 149 installed files matched the commit.
- Runtime probe: panel content remained visible; native inner sidebar controls and splitters stayed hidden on both sides in floating and pinned modes; close/reopen passed; main-window vertical tabs remained visible; saved settings were unchanged.
- ESLint, Node syntax check, changed-file Prettier, and `git diff --check` passed. Repository-wide Prettier still reports existing formatting issues in `css/customization.mjs` and `css/sidebar_box.mjs`.


