### PR TITLE
Add an option to disable window dragging from the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ https://github.com/user-attachments/assets/cd79d644-ca2c-4a30-ae8e-c265f41768b6
 - Actions: `Show` • `Hide`
 - Customize via [Customize Toolbar...](https://support.mozilla.org/en-US/kb/customize-firefox-controls-buttons-and-toolbars)
 - Settings:
-  - General: `Position (Left / Right)` • `Width`
+  - General: `Position (Left / Right)` • `Width` • `Allow window dragging`
   - Visibility: `Auto-hide sidebar` • `Auto-hide behaiour (Inline / Overlay)` • `Hide web panel when sidebar is hidden` • `Set shortcut to hide/show sidebar`
   - Web panel: `Default floating panel offset` • `New panel position (Before plus button / After plus button)` • `Show geometry hint`
   - Web panel button: `Container indicator (Off / Left / Right / Top / Bottom / Around)` • `Tooltip (Off / Title / URL / Title and URL)` • `Show full URL in tooltip`
   - Web panel toolbar: `Auto-hide forward button` • `Auto-hide back button`
   - Animations: `Animate sidebar` • `Animate web panel toolbar`
+
+Disable `Allow window dragging` to prevent dragging or double-clicking empty sidebar space from moving or maximizing/restoring the Firefox window.
 
 ### Web panels
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ https://github.com/user-attachments/assets/cd79d644-ca2c-4a30-ae8e-c265f41768b6
   - Web panel toolbar: `Auto-hide forward button` • `Auto-hide back button`
   - Animations: `Animate sidebar` • `Animate web panel toolbar`
 
-Disable `Allow window dragging` to prevent dragging or double-clicking empty sidebar space from moving or maximizing/restoring the Firefox window.
-
 ### Web panels
 
 - Actions: `Create` • `Delete` • `Edit` • `Change position and size` • `Reset position and size` • `Unload` • `Mute` • `Unmute` • `Pin` • `Unpin` • `Change zoom` • `Go back` • `Go forward` • `Reload` • `Go home`

--- a/src/second_sidebar/controllers/events.mjs
+++ b/src/second_sidebar/controllers/events.mjs
@@ -37,6 +37,7 @@ export const WebPanelEvents = {
 export const SidebarEvents = {
   EDIT_SIDEBAR_POSITION: "edit_sidebar_position",
   EDIT_SIDEBAR_PADDING: "edit_sidebar_padding",
+  EDIT_SIDEBAR_ALLOW_WINDOW_DRAGGING: "edit_sidebar_allow_window_dragging",
   EDIT_SIDEBAR_NEW_WEB_PANEL_POSITION: "edit_sidebar_new_web_panel_position",
   EDIT_SIDEBAR_DEFAULT_FLOATING_OFFSET: "edit_sidebar_floating_padding",
   EDIT_SIDEBAR_AUTO_HIDE_BACK_BUTTON: "edit_sidebar_auto_hide_back_button",

--- a/src/second_sidebar/controllers/sidebar.mjs
+++ b/src/second_sidebar/controllers/sidebar.mjs
@@ -88,6 +88,10 @@ export class SidebarController {
       SidebarControllers.sidebarMainController.setPadding(value);
     });
 
+    listenEvent(SidebarEvents.EDIT_SIDEBAR_ALLOW_WINDOW_DRAGGING, (event) => {
+      SidebarElements.sidebarMain.setAllowWindowDragging(event.detail.value);
+    });
+
     listenEvent(SidebarEvents.EDIT_SIDEBAR_NEW_WEB_PANEL_POSITION, (event) => {
       const value = event.detail.value;
       SidebarControllers.webPanelNewController.setNewWebPanelPosition(value);
@@ -377,6 +381,9 @@ export class SidebarController {
   loadSettings(settings) {
     SidebarElements.sidebarWrapper.setPosition(settings.position);
     SidebarControllers.sidebarMainController.setPadding(settings.padding);
+    SidebarElements.sidebarMain.setAllowWindowDragging(
+      settings.allowWindowDragging,
+    );
     SidebarControllers.webPanelNewController.setNewWebPanelPosition(
       settings.newWebPanelPosition,
     );
@@ -413,6 +420,7 @@ export class SidebarController {
     return new SidebarSettings({
       position: SidebarElements.sidebarWrapper.getPosition(),
       padding: SidebarControllers.sidebarMainController.getPadding(),
+      allowWindowDragging: SidebarElements.sidebarMain.getAllowWindowDragging(),
       newWebPanelPosition:
         SidebarControllers.webPanelNewController.getNewWebPanelPosition(),
       defaultFloatingOffset:

--- a/src/second_sidebar/controllers/sidebar_main_settings.mjs
+++ b/src/second_sidebar/controllers/sidebar_main_settings.mjs
@@ -14,6 +14,8 @@ export class SidebarMainSettingsController {
         sendEvents(SidebarEvents.EDIT_SIDEBAR_POSITION, { value }),
       padding: (value) =>
         sendEvents(SidebarEvents.EDIT_SIDEBAR_PADDING, { value }),
+      allowWindowDragging: (value) =>
+        sendEvents(SidebarEvents.EDIT_SIDEBAR_ALLOW_WINDOW_DRAGGING, { value }),
       newWebPanelPosition: (value) =>
         sendEvents(SidebarEvents.EDIT_SIDEBAR_NEW_WEB_PANEL_POSITION, {
           value,

--- a/src/second_sidebar/settings/sidebar_settings.mjs
+++ b/src/second_sidebar/settings/sidebar_settings.mjs
@@ -8,6 +8,7 @@ export class SidebarSettings {
    * @param {object} params
    * @param {string} params.position
    * @param {string} params.padding
+   * @param {boolean} params.allowWindowDragging
    * @param {string} params.newWebPanelPosition
    * @param {string} params.defaultFloatingOffset
    * @param {boolean} params.autoHideBackButton
@@ -26,6 +27,7 @@ export class SidebarSettings {
   constructor({
     position = "right",
     padding = "small",
+    allowWindowDragging = true,
     newWebPanelPosition = "before",
     defaultFloatingOffset = "small",
     autoHideBackButton = false,
@@ -43,6 +45,7 @@ export class SidebarSettings {
   }) {
     this.position = position;
     this.padding = padding;
+    this.allowWindowDragging = allowWindowDragging;
     this.newWebPanelPosition = newWebPanelPosition;
     this.defaultFloatingOffset = defaultFloatingOffset;
     this.autoHideBackButton = autoHideBackButton;
@@ -68,6 +71,7 @@ export class SidebarSettings {
     return new SidebarSettings({
       position: pref.position,
       padding: pref.padding,
+      allowWindowDragging: pref.allowWindowDragging,
       newWebPanelPosition: pref.newWebPanelPosition,
       defaultFloatingOffset: pref.defaultFloatingOffset,
       autoHideBackButton: pref.autoHideBackButton,
@@ -89,6 +93,7 @@ export class SidebarSettings {
     Settings.save(PREF, {
       position: this.position,
       padding: this.padding,
+      allowWindowDragging: this.allowWindowDragging,
       newWebPanelPosition: this.newWebPanelPosition,
       defaultFloatingOffset: this.defaultFloatingOffset,
       autoHideBackButton: this.autoHideBackButton,

--- a/src/second_sidebar/xul/sidebar_main.mjs
+++ b/src/second_sidebar/xul/sidebar_main.mjs
@@ -8,4 +8,21 @@ export class SidebarMain extends Toolbar {
       .setAttribute("customizable", "true")
       .setAttribute("fullscreentoolbar", "true");
   }
+
+  /**
+   *
+   * @returns {boolean}
+   */
+  getAllowWindowDragging() {
+    return !this.hasAttribute("nowindowdrag");
+  }
+
+  /**
+   *
+   * @param {boolean} value
+   * @returns {SidebarMain}
+   */
+  setAllowWindowDragging(value) {
+    return this.toggleAttribute("nowindowdrag", !value);
+  }
 }

--- a/src/second_sidebar/xul/sidebar_main_popup_settings.mjs
+++ b/src/second_sidebar/xul/sidebar_main_popup_settings.mjs
@@ -35,6 +35,9 @@ export class SidebarMainPopupSettings extends Panel {
 
     this.positionMenuList = this.#createPositionMenuList();
     this.paddingMenuList = this.#createPaddingMenuList();
+    this.allowWindowDraggingToggle = new Toggle({
+      id: "sb2-main-popup-settings-allow-window-dragging-toggle",
+    });
     this.newWebPanelPositionMenuList =
       this.#createNewWebPanelPositionMenuList();
     this.autoHideBackToggle = new Toggle();
@@ -183,6 +186,11 @@ export class SidebarMainPopupSettings extends Panel {
             createPopupGroup("Position", this.positionMenuList),
             new ToolbarSeparator(),
             createPopupGroup("Width", this.paddingMenuList),
+            new ToolbarSeparator(),
+            createPopupGroup(
+              "Allow window dragging",
+              this.allowWindowDraggingToggle,
+            ),
           ]),
           createPopupSet("Visibility", [
             createPopupGroup("Auto-hide sidebar", this.autoHideSidebarToggle),
@@ -269,6 +277,7 @@ export class SidebarMainPopupSettings extends Panel {
    * @param {object} callbacks
    * @param {function(string):void} callbacks.position
    * @param {function(string):void} callbacks.padding
+   * @param {function(boolean):void} callbacks.allowWindowDragging
    * @param {function(string):void} callbacks.newWebPanelPosition
    * @param {function(string):void} callbacks.defaultFloatingOffset
    * @param {function(boolean):void} callbacks.autoHideBackButton
@@ -283,6 +292,7 @@ export class SidebarMainPopupSettings extends Panel {
   listenChanges({
     position,
     padding,
+    allowWindowDragging,
     newWebPanelPosition,
     defaultFloatingOffset,
     autoHideBackButton,
@@ -297,6 +307,7 @@ export class SidebarMainPopupSettings extends Panel {
   }) {
     this.onPositionChange = position;
     this.onPaddingChange = padding;
+    this.onAllowWindowDraggingChange = allowWindowDragging;
     this.onNewWebPanelPositionChange = newWebPanelPosition;
     this.onDefaultFloatingOffsetChange = defaultFloatingOffset;
     this.onAutoHideBackButtonChange = autoHideBackButton;
@@ -314,6 +325,9 @@ export class SidebarMainPopupSettings extends Panel {
     );
     this.paddingMenuList.addEventListener("command", () =>
       padding(this.paddingMenuList.getValue()),
+    );
+    this.allowWindowDraggingToggle.addEventListener("toggle", () =>
+      allowWindowDragging(this.allowWindowDraggingToggle.getPressed()),
     );
     this.newWebPanelPositionMenuList.addEventListener("command", () =>
       newWebPanelPosition(this.newWebPanelPositionMenuList.getValue()),
@@ -413,6 +427,7 @@ export class SidebarMainPopupSettings extends Panel {
   openPopupAtScreen(screenX, screenY, settings) {
     this.positionMenuList.setValue(settings.position);
     this.paddingMenuList.setValue(settings.padding);
+    this.allowWindowDraggingToggle.setPressed(settings.allowWindowDragging);
     this.newWebPanelPositionMenuList.setValue(settings.newWebPanelPosition);
     this.defaultFloatingOffsetMenuList.setValue(settings.defaultFloatingOffset);
     this.autoHideBackToggle.setPressed(settings.autoHideBackButton);
@@ -459,6 +474,12 @@ export class SidebarMainPopupSettings extends Panel {
     }
     if (this.paddingMenuList.getValue() !== this.settings.padding) {
       this.onPaddingChange(this.settings.padding);
+    }
+    if (
+      this.allowWindowDraggingToggle.getPressed() !==
+      this.settings.allowWindowDragging
+    ) {
+      this.onAllowWindowDraggingChange(this.settings.allowWindowDragging);
     }
     if (
       this.newWebPanelPositionMenuList.getValue() !==


### PR DESCRIPTION
Dragging or double-clicking empty sidebar space can accidentally move or restore a maximized Firefox window. Add an **Allow window dragging** setting that disables those actions through Firefox's native `nowindowdrag` toolbar attribute.

The setting defaults to enabled for existing profiles, applies immediately across browser windows, is restored by Cancel, and persists with Save. The README lists the new setting.

Fixes #188.

## Validation

- ESLint, Prettier for the changed files, and `git diff --check` pass.
- A temporary privileged integration probe passed on Firefox 155.0.1 / Windows with fx-autoconfig: legacy defaults, native CSS rule matching, popup toggle/Save/Cancel, two-window propagation, left/right placement, the toolbar's `customizing` attribute, and persistence after restart. Original settings were restored after testing; no FSS errors were recorded.
- Physical mouse dragging, double-click actions, and a full Customize Toolbar interaction remain unverified because desktop browser automation was unavailable.
- Full-tree Prettier still reports existing formatting issues in `src/second_sidebar/css/customization.mjs` and `src/second_sidebar/css/sidebar_box.mjs`; neither file is changed here.
