### PR TITLE
Add a periodic reload countdown badge

### DIFF
--- a/src/second_sidebar/controllers/sidebar.mjs
+++ b/src/second_sidebar/controllers/sidebar.mjs
@@ -198,6 +198,7 @@ export class SidebarController {
   close() {
     SidebarControllers.sidebarToolbarCollapser.clearTimers();
     SidebarElements.sidebarBox.hide();
+    SidebarElements.sidebarToolbar.setPeriodicReloadPanelUUID(null);
     SidebarElements.sidebarSplitter.hide();
     SidebarElements.afterSplitter.hide();
     SidebarControllers.webPanelsController.close();
@@ -251,7 +252,8 @@ export class SidebarController {
     SidebarElements.sidebarToolbar
       .setTitle(title)
       .toggleBackButton(!canGoBack)
-      .toggleForwardButton(!canGoForward);
+      .toggleForwardButton(!canGoForward)
+      .setPeriodicReloadPanelUUID(webPanelController.getUUID());
 
     const hideToolbar = webPanelController.getHideToolbar();
     hideToolbar ? this.collapseToolbar() : this.uncollapseToolbar();

--- a/src/second_sidebar/controllers/web_panel.mjs
+++ b/src/second_sidebar/controllers/web_panel.mjs
@@ -25,8 +25,10 @@ export class WebPanelController {
   #button;
   /**@type {WebPanelTab?} */
   #tab = null;
-  /**@type {number} */
-  #interval = null;
+  /**@type {number?} */
+  #reloadTimer = null;
+  /**@type {number?} */
+  #nextReloadAt = null;
 
   /**
    *
@@ -409,21 +411,45 @@ export class WebPanelController {
 
   #startTimer() {
     this.#stopTimer();
-    if (this.#settings.periodicReload == 0) {
+    const interval = Number(this.#settings.periodicReload);
+    if (this.isUnloaded() || !Number.isFinite(interval) || interval <= 0) {
       return;
     }
-    this.#log("start timer", this.#settings.periodicReload);
-    this.#interval = setInterval(() => {
-      this.#log("periodic reload");
-      this.reload();
-    }, this.#settings.periodicReload);
+    this.#log("start timer", interval);
+    this.#nextReloadAt = Date.now() + interval;
+    this.#reloadTimer = setTimeout(
+      () => {
+        this.#reloadTimer = null;
+        this.#log("periodic reload");
+        this.reload();
+      },
+      Math.max(0, this.#nextReloadAt - Date.now()),
+    );
+    this.#refreshPeriodicReloadIndicator();
   }
 
   #stopTimer() {
-    if (this.#interval) {
+    if (this.#reloadTimer !== null) {
       this.#log("stop timer");
-      clearInterval(this.#interval);
+      clearTimeout(this.#reloadTimer);
     }
+    this.#reloadTimer = null;
+    this.#nextReloadAt = null;
+    this.#refreshPeriodicReloadIndicator();
+  }
+
+  #refreshPeriodicReloadIndicator() {
+    SidebarElements.sidebarToolbar.refreshPeriodicReload(this.getUUID());
+  }
+
+  /**
+   *
+   * @returns {number?}
+   */
+  getPeriodicReloadRemaining() {
+    return this.#nextReloadAt === null
+      ? null
+      : Math.max(0, this.#nextReloadAt - Date.now());
   }
 
   /**
@@ -435,6 +461,10 @@ export class WebPanelController {
   }
 
   reload() {
+    if (this.isUnloaded()) {
+      return;
+    }
+    this.#startTimer();
     this.#tab.linkedBrowser.reload();
   }
 
@@ -831,6 +861,7 @@ export class WebPanelController {
   }
 
   remove() {
+    this.#stopTimer();
     if (this.#tab) {
       SidebarElements.webPanelsBrowser.removeWebPanelTab(this.#tab);
     }

--- a/src/second_sidebar/css/sidebar_box.mjs
+++ b/src/second_sidebar/css/sidebar_box.mjs
@@ -86,6 +86,31 @@ export const SIDEBAR_BOX_CSS = `
           cursor: inherit;
         }
       }
+
+      #sb2-toolbar-reload {
+        position: relative;
+      }
+
+      #sb2-toolbar-periodic-reload {
+        position: absolute;
+        z-index: 1;
+        bottom: 1px;
+        inset-inline: 0;
+        width: max-content;
+        min-width: 4ch;
+        margin: 0 auto;
+        padding: 0 2px;
+        border-radius: var(--border-radius-small, 3px);
+        background-color: Canvas;
+        color: CanvasText;
+        box-shadow: 0 0 0 1px color-mix(in srgb, CanvasText 25%, Canvas);
+        font-size: 9px;
+        line-height: 11px;
+        font-variant-numeric: tabular-nums;
+        text-align: center;
+        white-space: nowrap;
+        pointer-events: none;
+      }
     }
   }
 

--- a/src/second_sidebar/utils/string.mjs
+++ b/src/second_sidebar/utils/string.mjs
@@ -21,3 +21,17 @@ export function parseNotifications(text) {
   }
   return result[2];
 }
+
+/**
+ *
+ * @param {number} milliseconds
+ * @returns {string}
+ */
+export function formatReloadCountdown(milliseconds) {
+  const value = Number(milliseconds);
+  const clampedMilliseconds = Number.isFinite(value) ? Math.max(0, value) : 0;
+  const totalSeconds = Math.ceil(clampedMilliseconds / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = String(totalSeconds % 60).padStart(2, "0");
+  return `${minutes}:${seconds}`;
+}

--- a/src/second_sidebar/xul/periodic_reload_badge.mjs
+++ b/src/second_sidebar/xul/periodic_reload_badge.mjs
@@ -1,0 +1,36 @@
+import { Label } from "./base/label.mjs";
+import { formatReloadCountdown } from "../utils/string.mjs";
+
+export class PeriodicReloadBadge extends Label {
+  /**@type {string?} */
+  #text = null;
+
+  constructor() {
+    super({ id: "sb2-toolbar-periodic-reload" });
+    this.setAttribute("aria-hidden", "true").hide();
+  }
+
+  /**
+   *
+   * @param {number?} remaining
+   * @returns {PeriodicReloadBadge}
+   */
+  setRemaining(remaining) {
+    const text = remaining === null ? null : formatReloadCountdown(remaining);
+    if (text === this.#text) {
+      return this;
+    }
+    this.#text = text;
+    this.setText(text ?? "");
+    text === null ? this.hide() : this.show();
+    return this;
+  }
+
+  /**
+   *
+   * @returns {string?}
+   */
+  getText() {
+    return this.#text;
+  }
+}

--- a/src/second_sidebar/xul/sidebar_toolbar.mjs
+++ b/src/second_sidebar/xul/sidebar_toolbar.mjs
@@ -1,6 +1,8 @@
 import { Div } from "./base/div.mjs";
 import { HBox } from "./base/hbox.mjs";
 import { Label } from "./base/label.mjs";
+import { PeriodicReloadBadge } from "./periodic_reload_badge.mjs";
+import { SidebarControllers } from "../sidebar_controllers.mjs";
 import { Toolbar } from "./base/toolbar.mjs";
 import { ToolbarButton } from "./base/toolbar_button.mjs";
 import { isLeftMouseButton } from "../utils/buttons.mjs";
@@ -22,6 +24,12 @@ const ICONS = {
 };
 
 export class SidebarToolbar extends Toolbar {
+  /**@type {string?} */
+  #periodicReloadPanelUUID = null;
+  /** @type {number?} */
+  #countdownUpdateInterval = null;
+  #destroyed = false;
+
   constructor() {
     super({ id: "sb2-toolbar" });
     this.setMode("icons").setAttribute("fullscreentoolbar", "true");
@@ -34,6 +42,8 @@ export class SidebarToolbar extends Toolbar {
     this.backButton = this.#createButton("Back", ICONS.BACK);
     this.forwardButton = this.#createButton("Forward", ICONS.FORWARD);
     this.reloadButton = this.#createButton("Reload", ICONS.RELOAD);
+    this.periodicReloadBadge = new PeriodicReloadBadge();
+    this.reloadButtonWrapper = this.#createReloadButtonWrapper();
     this.homeButton = this.#createButton("Home", ICONS.HOME);
     this.navButtons = this.#createNavButtons();
 
@@ -48,6 +58,28 @@ export class SidebarToolbar extends Toolbar {
     this.pinButton = this.#createButton();
     this.closeButton = this.#createButton("Unload", ICONS.CLOSE);
     this.sidebarButtons = this.#createSidebarButtons();
+    this.#setupCountdownListeners();
+  }
+
+  #setupCountdownListeners() {
+    const onVisibilityChange = () => this.refreshPeriodicReload();
+    const observer = new MutationObserver(onVisibilityChange);
+    observer.observe(this.element, {
+      attributes: true,
+      attributeFilter: ["style"],
+    });
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener(
+      "unload",
+      () => {
+        this.#destroyed = true;
+        this.#periodicReloadPanelUUID = null;
+        this.#stopCountdownUpdates();
+        observer.disconnect();
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      },
+      { once: true },
+    );
   }
 
   /**
@@ -82,11 +114,21 @@ export class SidebarToolbar extends Toolbar {
     const toolbarButtons = new HBox({ id: "sb2-toolbar-nav-buttons" })
       .appendChild(this.backButton)
       .appendChild(this.forwardButton)
-      .appendChild(this.reloadButton)
+      .appendChild(this.reloadButtonWrapper)
       .appendChild(this.homeButton);
 
     this.appendChild(toolbarButtons);
     return toolbarButtons;
+  }
+
+  /**
+   *
+   * @returns {HBox}
+   */
+  #createReloadButtonWrapper() {
+    return new HBox({ id: "sb2-toolbar-reload" })
+      .appendChild(this.reloadButton)
+      .appendChild(this.periodicReloadBadge);
   }
 
   /**
@@ -184,6 +226,75 @@ export class SidebarToolbar extends Toolbar {
   setTitle(title) {
     this.toolbarTitle.setText(title);
     return this;
+  }
+
+  /**
+   *
+   * @param {string?} uuid
+   * @returns {SidebarToolbar}
+   */
+  setPeriodicReloadPanelUUID(uuid) {
+    if (!this.#destroyed) {
+      this.#periodicReloadPanelUUID = uuid;
+      this.refreshPeriodicReload();
+    }
+    return this;
+  }
+
+  /**
+   * Update the displayed panel's countdown without changing the toolbar.
+   * @param {string?} uuid
+   * @returns {SidebarToolbar}
+   */
+  refreshPeriodicReload(uuid = null) {
+    if (uuid !== null && uuid !== this.#periodicReloadPanelUUID) {
+      return this;
+    }
+
+    const collapsed = !["0px", ""].includes(this.getProperty("margin-top"));
+    const remaining =
+      this.#destroyed || collapsed || document.hidden
+        ? null
+        : (SidebarControllers.webPanelsController
+            ?.get(this.#periodicReloadPanelUUID)
+            ?.getPeriodicReloadRemaining() ?? null);
+    this.#updatePeriodicReloadBadge(remaining);
+    if (remaining === null) {
+      this.#stopCountdownUpdates();
+    } else if (this.#countdownUpdateInterval === null) {
+      this.#countdownUpdateInterval = setInterval(
+        () => this.refreshPeriodicReload(),
+        1000,
+      );
+    }
+    return this;
+  }
+
+  #stopCountdownUpdates() {
+    clearInterval(this.#countdownUpdateInterval);
+    this.#countdownUpdateInterval = null;
+  }
+
+  /**
+   *
+   * @param {number?} remaining
+   */
+  #updatePeriodicReloadBadge(remaining) {
+    const previousText = this.periodicReloadBadge.getText();
+    this.periodicReloadBadge.setRemaining(remaining);
+    const text = this.periodicReloadBadge.getText();
+    if (text === previousText) {
+      return;
+    }
+
+    if (text === null) {
+      this.reloadButton.removeAttribute("aria-label");
+    } else {
+      this.reloadButton.setAttribute(
+        "aria-label",
+        `Reload; automatic reload in ${text}`,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
Panels with periodic reload enabled now show the time until the next reload as a compact badge at the bottom of the Reload button. The badge uses an opaque, theme-aware background and updates once per second in `m:ss` format without changing toolbar dimensions.

The countdown and reload share one in-memory deadline and a cancellable timeout. Reloading through FSS starts a full interval again; interval changes apply immediately, while disabling reload, unloading, or removing the panel clears the schedule. Loaded panels retain their schedule while closed, and delayed callbacks trigger one reload before starting a new interval.

`SidebarToolbar` owns the display timer and tracks the selected panel by UUID. A separate `PeriodicReloadBadge` component handles formatting and text updates. The display timer stops when the toolbar or window is hidden and is cleaned up on window unload.

Validation:

- ESLint, Prettier on all changed files, and `git diff --check` pass.
- Local deterministic checks pass for scheduling, manual reset, interval changes, lifecycle cleanup, UUID switching, visibility, and countdown formatting.
- Repository-wide Prettier still reports existing formatting issues in unchanged files.
- Firefox runtime and visual verification of the final revision remain pending.
