### PR TITLE
Fix web panel badge initialization before native rendering

### DIFF
--- a/src/second_sidebar/xul/base/widget.mjs
+++ b/src/second_sidebar/xul/base/widget.mjs
@@ -3,6 +3,17 @@ import { ToolbarButton } from "./toolbar_button.mjs";
 import { XULElement } from "./xul_element.mjs"; // eslint-disable-line no-unused-vars
 
 export class Widget {
+  #readyCleanups = new Set();
+  #removed = false;
+
+  #clearReadyCallbacks = () => {
+    this.#removed = true;
+    for (const cleanup of this.#readyCleanups) {
+      cleanup();
+    }
+    this.#readyCleanups.clear();
+  };
+
   /**
    *
    * @param {object} params
@@ -36,6 +47,9 @@ export class Widget {
     this.unloaded = unloaded;
     this.context = context;
     this.onClick = null;
+    window.addEventListener("unload", this.#clearReadyCallbacks, {
+      once: true,
+    });
     try {
       this.wrapper = CustomizableUIWrapper.createWidget({
         id,
@@ -266,6 +280,8 @@ export class Widget {
    * @returns {Widget}
    */
   remove() {
+    this.#clearReadyCallbacks();
+    window.removeEventListener("unload", this.#clearReadyCallbacks);
     CustomizableUIWrapper.destroyWidget(this.id);
     return this;
   }
@@ -276,25 +292,39 @@ export class Widget {
    * @returns {Widget}
    */
   doWhenButtonReady(callback) {
+    if (this.#removed) return this;
     const interval = setInterval(() => {
       if (!this.button) return;
-      clearInterval(interval);
+      cleanup();
+      this.#readyCleanups.delete(cleanup);
       callback();
     }, 100);
+    const cleanup = () => clearInterval(interval);
+    this.#readyCleanups.add(cleanup);
     return this;
   }
 
   /**
    *
-   * @param {function():void} callback
+   * @param {function(HTMLElement):void} callback
    * @returns {Widget}
    */
-  doWhenButtonImageReady(callback) {
-    const interval = setInterval(() => {
-      if (!this.button.getImageXUL()) return;
-      clearInterval(interval);
-      callback();
-    }, 100);
-    return this;
+  doWhenBadgeStackReady(callback) {
+    return this.doWhenButtonReady(() => {
+      const button = this.button;
+      const onReady = () => {
+        const badgeStack = button.getBadgeStackXUL();
+        if (!badgeStack) return;
+        cleanup();
+        this.#readyCleanups.delete(cleanup);
+        callback(badgeStack);
+      };
+      const observer = new MutationObserver(onReady);
+      const cleanup = () => observer.disconnect();
+      this.#readyCleanups.add(cleanup);
+      // Firefox renders a button's children only after insertion or popup opening.
+      observer.observe(button.element, { childList: true });
+      onReady();
+    });
   }
 }

--- a/src/second_sidebar/xul/web_panel_button.mjs
+++ b/src/second_sidebar/xul/web_panel_button.mjs
@@ -27,8 +27,7 @@ export class WebPanelButton extends Widget {
 
     this.soundIcon = new WebPanelSoundIcon();
     this.notificationBadge = new NotificationBadge();
-    this.doWhenButtonReady(() => {
-      const badgeStackXUL = this.button.getBadgeStackXUL();
+    this.doWhenBadgeStackReady((badgeStackXUL) => {
       badgeStackXUL.appendChild(this.soundIcon.element);
       badgeStackXUL.appendChild(this.notificationBadge.element);
     });
@@ -128,10 +127,8 @@ export class WebPanelButton extends Widget {
    * @returns {WebPanelButton}
    */
   setUserContextId(userContextId) {
-    return this.doWhenButtonReady(() =>
-      this.doWhenButtonImageReady(() =>
-        applyContainerColor(userContextId, this.button.getBadgeStackXUL()),
-      ),
+    return this.doWhenBadgeStackReady((badgeStackXUL) =>
+      applyContainerColor(userContextId, badgeStackXUL),
     );
   }
 


### PR DESCRIPTION
Web panel buttons can exist before Firefox renders their internal badge stack, particularly when a saved button has no toolbar placement or belongs to an unopened popup. Initializing the sound and notification icons at that point throws `badgeStackXUL is null` and leaves them unattached.

Wait for the native badge stack with a one-shot `MutationObserver`, and use the same readiness helper when applying container colors. Cancel pending readiness timers and observers when a widget is removed or its window closes.

Validation:

- ESLint, Prettier on both changed files, and `git diff --check` pass.
- Deterministic regression checks reproduce the previous failure and pass with the fix, including delayed rendering and cleanup before readiness.
- Firefox 155.0.1 on Windows: normal startup passes with no FSS/fx-autoconfig console errors; 150 deployed files match the commit and loader files remain unchanged.
- Fourteen headless runtime checks pass for detached buttons, delayed popup rendering, notification/sound state, container colors, moving/removing widgets, and the same widget UUID in two windows. Temporary diagnostic scripts and test widgets were removed afterward.
