### PR TITLE
fix: avoid sending credentials for icon availability checks

### DIFF
--- a/src/second_sidebar/utils/icons.mjs
+++ b/src/second_sidebar/utils/icons.mjs
@@ -71,7 +71,7 @@ export function fetchIconURL(url) {
  */
 export async function isIconAvailable(url) {
   try {
-    const response = await fetch(url, { credentials: "include" });
+    const response = await fetch(url, { credentials: "omit" });
     return response.status === 200;
   } catch {
     return false;


### PR DESCRIPTION
## Summary
Removes unnecessary browser credentials from the `fetch()` request in `isIconAvailable()` (`src/second_sidebar/utils/icons.mjs`), used via `useAvailableIcon()`.

```diff
- const response = await fetch(url, { credentials: "include" });
+ const response = await fetch(url, { credentials: "omit" });
```

## Scope correction

This PR was originally opened as a HIGH-severity SSRF / credential-leak fix (auto-generated report, rule V-001). After the maintainer traced the actual call graph, that classification does not hold, and I've verified it independently:

- `isIconAvailable()` is only called through `useAvailableIcon()`, whose sole caller is `src/second_sidebar/xul/sidebar_toolbar.mjs:309-310`.
- The URLs passed there are always the hardcoded constants `ICONS.PINNED`, `ICONS.PINNED_ALT`, `ICONS.FLOATING`, `ICONS.FLOATING_ALT` (`sidebar_toolbar.mjs:11-23`) — literal built-in `chrome://...` strings. Nothing from web panel configuration, settings, or user input reaches this code path.
- User-configured favicon URLs are resolved by a separate function, `fetchIconURL()` in the same file, which this PR does not touch.
- `credentials: "omit"` only controls whether cookies/credentials are attached to the request; it does not restrict the request destination, so it would not mitigate SSRF even if the URL were attacker-controlled.

There is no reproducible PoC to offer, because the described attack path does not exist in the current code.

## What this PR actually does
A small defense-in-depth cleanup: the icon-availability probe no longer attaches browser credentials to a request whose destination is always a hardcoded, built-in resource. It is not a fix for a demonstrated SSRF or credential-leak vulnerability.

## Testing
Behavior preserved — verified in Firefox 155.0.1 (privileged context, Windows) that `include` and `omit` produce identical results for these icon URLs.