### PR TITLE
Fix link context menus and temporary panel behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ https://github.com/user-attachments/assets/cd79d644-ca2c-4a30-ae8e-c265f41768b6
 
 - Actions: `Create` • `Delete` • `Edit` • `Change position and size` • `Reset position and size` • `Unload` • `Mute` • `Unmute` • `Pin` • `Unpin` • `Change zoom` • `Go back` • `Go forward` • `Reload` • `Go home`
 - Extensions support
+- Link context menu: `Open Link in Second Sidebar` • `Preview Link in Second Sidebar` (shown only for links that Firefox can open in a tab)
 - Popup notifications support (permissions to use microphone/camera/location, etc.)
 - Settings:
   - General: `URL` • `Multi-Account Container` • `Temporary` • `Mobile view` • `Zoom`

--- a/src/second_sidebar/controllers/context_menu_items.mjs
+++ b/src/second_sidebar/controllers/context_menu_items.mjs
@@ -36,14 +36,8 @@ export class ContextMenuItemsController {
 
   #onPopupShowing() {
     const hideLinkItems = !gContextMenu.onSaveableLink;
-    SidebarElements.openLinkAsWebPanelMenuItem.toggleAttribute(
-      "hidden",
-      hideLinkItems,
-    );
-    SidebarElements.openLinkAsTempWebPanelMenuItem.toggleAttribute(
-      "hidden",
-      hideLinkItems,
-    );
+    SidebarElements.openLinkAsWebPanelMenuItem.toggleHidden(hideLinkItems);
+    SidebarElements.openLinkAsTempWebPanelMenuItem.toggleHidden(hideLinkItems);
     gContextMenu.showItem(
       "context-sep-open",
       gContextMenu.shouldShowSeparator("context-sep-open"),

--- a/src/second_sidebar/controllers/context_menu_items.mjs
+++ b/src/second_sidebar/controllers/context_menu_items.mjs
@@ -13,7 +13,10 @@ export class ContextMenuItemsController {
   #setupListeners() {
     BrowserElements.contentAreaContextMenu.addEventListener(
       "popupshowing",
-      () => this.#onPopupShowing(),
+      (event) => {
+        if (event.target !== event.currentTarget) return;
+        this.#onPopupShowing();
+      },
     );
 
     SidebarElements.openLinkAsWebPanelMenuItem.addEventListener("command", () =>
@@ -32,6 +35,16 @@ export class ContextMenuItemsController {
   }
 
   #onPopupShowing() {
+    const hideLinkItems = !gContextMenu.onSaveableLink;
+    SidebarElements.openLinkAsWebPanelMenuItem.toggleAttribute(
+      "hidden",
+      hideLinkItems,
+    );
+    SidebarElements.openLinkAsTempWebPanelMenuItem.toggleAttribute(
+      "hidden",
+      hideLinkItems,
+    );
+
     this.searchQuery = gContextMenu.selectedText || gContextMenu.linkTextStr;
     SidebarElements.searchInWebPanelMenuItem.setSearchQuery(this.searchQuery);
   }

--- a/src/second_sidebar/controllers/context_menu_items.mjs
+++ b/src/second_sidebar/controllers/context_menu_items.mjs
@@ -44,6 +44,10 @@ export class ContextMenuItemsController {
       "hidden",
       hideLinkItems,
     );
+    gContextMenu.showItem(
+      "context-sep-open",
+      gContextMenu.shouldShowSeparator("context-sep-open"),
+    );
 
     this.searchQuery = gContextMenu.selectedText || gContextMenu.linkTextStr;
     SidebarElements.searchInWebPanelMenuItem.setSearchQuery(this.searchQuery);

--- a/src/second_sidebar/controllers/sidebar.mjs
+++ b/src/second_sidebar/controllers/sidebar.mjs
@@ -74,7 +74,9 @@ export class SidebarController {
       const webPanelController =
         SidebarControllers.webPanelsController.getActive();
       this.close();
-      webPanelController.unload();
+      if (!webPanelController.isUnloaded()) {
+        webPanelController.unload();
+      }
     });
 
     listenEvent(SidebarEvents.EDIT_SIDEBAR_POSITION, (event) => {

--- a/src/second_sidebar/css/context_item.mjs
+++ b/src/second_sidebar/css/context_item.mjs
@@ -1,10 +1,4 @@
 export const CONTEXT_ITEM_CSS = `
-  #contentAreaContextMenu:has(#context-openlink[hidden="true"]) {
-    #context-openlinkaswebpanel, #context-openlinkastempwebpanel, #context-sep-open {
-      display: none;
-    }
-  }
-
   menuitem[label="Reset Zoom [100%]"] {
     display: none;
   }

--- a/src/second_sidebar/css/sidebar_main.mjs
+++ b/src/second_sidebar/css/sidebar_main.mjs
@@ -116,7 +116,10 @@ export const SIDEBAR_MAIN_CSS = `
   }
 
   .sb2-main-button[temporary="true"] > stack.toolbarbutton-badge-stack {
-    background-color: var(--attention-dot-color) !important;
+    background-color: var(
+      --attention-dot-color,
+      var(--button-attention-dot-color, var(--color-accent-attention, AccentColor))
+    ) !important;
   }
 
   .sb2-main-button:not([image]):not([loading]) .toolbarbutton-icon {

--- a/src/second_sidebar/patchers/urlbar_input_patcher.mjs
+++ b/src/second_sidebar/patchers/urlbar_input_patcher.mjs
@@ -2,6 +2,7 @@ export class UrlbarInputPatcher {
   static patch() {
     console.log("Patching #urlbar-input...");
     this.#defineLazyGetter();
+    this.#patchTabSwitchFocusChange();
     console.log("#urlbar-input was patched");
   }
 
@@ -9,5 +10,18 @@ export class UrlbarInputPatcher {
     const childWindow = window[1];
     const urlbarInput = childWindow.document.querySelector("#urlbar-input");
     ChromeUtils.defineLazyGetter(urlbarInput, "editor", () => null);
+  }
+
+  static #patchTabSwitchFocusChange() {
+    const urlbar = window[1].gURLBar;
+    const afterTabSelectAndFocusChange = urlbar._afterTabSelectAndFocusChange;
+    if (typeof afterTabSelectAndFocusChange !== "function") return;
+
+    urlbar._afterTabSelectAndFocusChange = function (...args) {
+      // The hidden urlbar may have no view. Its focus handler must not
+      // interrupt tab removal before the temporary panel is deleted.
+      if (!this.view) return;
+      return afterTabSelectAndFocusChange.apply(this, args);
+    };
   }
 }

--- a/src/second_sidebar/xul/base/xul_element.mjs
+++ b/src/second_sidebar/xul/base/xul_element.mjs
@@ -84,6 +84,15 @@ export class XULElement {
 
   /**
    *
+   * @param {boolean} [force]
+   * @returns {XULElement}
+   */
+  toggleHidden(force) {
+    return this.toggleAttribute("hidden", force);
+  }
+
+  /**
+   *
    * @returns {boolean}
    */
   hidden() {


### PR DESCRIPTION
Right-clicking an empty page could show the sidebar link actions or leave an empty separator. Preview panels could also remain after closing because Firefox's hidden URL bar interrupted tab removal, and their buttons lost their colored background when Firefox renamed the attention color token.

This PR:
- Shows both link actions only for `gContextMenu.onSaveableLink`, ignores nested submenu events, and recomputes the native separator after updating visibility.
- Adds `XULElement.toggleHidden(force)` and documents the link actions in the README.
- Guards focus handling on the embedded window's uninitialized URL bar and avoids unloading a panel that closing has already removed.
- Restores temporary panel button backgrounds using the current attention color tokens, with legacy theme and system accent fallbacks.

Validation:
- `npx eslint .`, Prettier on all changed files, and `git diff --check origin/master...HEAD` passed.
- Firefox 155.0.1 on Windows: 13 headless menu/panel scenarios passed, including link/non-link contexts, separator transitions, temporary and permanent panels, button activation, and removal from the UI and saved panel settings.
- Light/dark color schemes and legacy/current/system color fallbacks passed. These behavioral checks ran on `1328a90`, before the final `toggleHidden` helper refactor.
- Final commit `275c231` was installed in the test profile and passed the normal Firefox startup check; all 150 deployed source files matched the commit.
