### PR TITLE
Keep web panels open after permission prompt actions

### DIFF
--- a/src/second_sidebar/patchers/popup_notifications_patcher.mjs
+++ b/src/second_sidebar/patchers/popup_notifications_patcher.mjs
@@ -4,46 +4,40 @@ const MODULE_URL = "resource://gre/modules/PopupNotifications.sys.mjs";
 const PATCHED_MODULE_RELATIVE_PATH = "fss/PopupNotifications.sys.mjs";
 
 export class PopupNotificationsPatcher {
-  /**
-   * @param {Window} childWindow
-   */
-  static patch(childWindow) {
+  static patch() {
     console.log("Patching PopupNotifications.sys.mjs...");
     fetch(MODULE_URL)
       .then(async (response) => {
         let moduleSource = await response.text();
         moduleSource = this.#patchModuleSource(moduleSource);
-        await this.#replaceModule(moduleSource, childWindow);
+        await this.#replaceModule(moduleSource);
       })
       .catch(console.error);
     console.log("PopupNotifications.sys.mjs was patched");
   }
 
   static #patchModuleSource(moduleSource) {
-    // The nested panel window cannot be the active top-level window. Check
-    // and focus its owner while preserving Firefox's early return and delay.
     return moduleSource
       .replace(/(let isActiveBrowser = ).+/gm, "$1true;")
       .replace(/(let isActiveWindow = ).+/gm, "$1true;")
-      .replace(/(Services\.focus\.activeWindow != this\.window)\b/g, "$1.top")
-      .replace(/this\.window\.focus\(\)/g, "this.window.top.focus()");
+      .replace(/(this\.window\.focus\(\);)\s+return;/gm, "$1");
   }
 
-  static async #replaceModule(moduleSource, childWindow) {
+  static async #replaceModule(moduleSource) {
     const chromePath = await writeFile(
       PATCHED_MODULE_RELATIVE_PATH,
       moduleSource,
     );
     const module = await import(chromePath);
-    this.#defineLazyGetter(module, childWindow);
+    this.#defineLazyGetter(module);
     await removeFile(PATCHED_MODULE_RELATIVE_PATH);
   }
 
   /**
    * @param {Object} module
-   * @param {Window} childWindow
    */
-  static #defineLazyGetter(module, childWindow) {
+  static #defineLazyGetter(module) {
+    const childWindow = window[1];
     ChromeUtils.defineLazyGetter(childWindow, "PopupNotifications", () => {
       try {
         let shouldSuppress = () => {

--- a/src/second_sidebar/patchers/popup_notifications_patcher.mjs
+++ b/src/second_sidebar/patchers/popup_notifications_patcher.mjs
@@ -4,40 +4,46 @@ const MODULE_URL = "resource://gre/modules/PopupNotifications.sys.mjs";
 const PATCHED_MODULE_RELATIVE_PATH = "fss/PopupNotifications.sys.mjs";
 
 export class PopupNotificationsPatcher {
-  static patch() {
+  /**
+   * @param {Window} childWindow
+   */
+  static patch(childWindow) {
     console.log("Patching PopupNotifications.sys.mjs...");
     fetch(MODULE_URL)
       .then(async (response) => {
         let moduleSource = await response.text();
         moduleSource = this.#patchModuleSource(moduleSource);
-        await this.#replaceModule(moduleSource);
+        await this.#replaceModule(moduleSource, childWindow);
       })
       .catch(console.error);
     console.log("PopupNotifications.sys.mjs was patched");
   }
 
   static #patchModuleSource(moduleSource) {
+    // The nested panel window cannot be the active top-level window. Check
+    // and focus its owner while preserving Firefox's early return and delay.
     return moduleSource
       .replace(/(let isActiveBrowser = ).+/gm, "$1true;")
       .replace(/(let isActiveWindow = ).+/gm, "$1true;")
-      .replace(/(this\.window\.focus\(\);)\s+return;/gm, "$1");
+      .replace(/(Services\.focus\.activeWindow != this\.window)\b/g, "$1.top")
+      .replace(/this\.window\.focus\(\)/g, "this.window.top.focus()");
   }
 
-  static async #replaceModule(moduleSource) {
+  static async #replaceModule(moduleSource, childWindow) {
     const chromePath = await writeFile(
       PATCHED_MODULE_RELATIVE_PATH,
       moduleSource,
     );
     const module = await import(chromePath);
-    this.#defineLazyGetter(module);
+    this.#defineLazyGetter(module, childWindow);
     await removeFile(PATCHED_MODULE_RELATIVE_PATH);
   }
 
   /**
    * @param {Object} module
+   * @param {Window} childWindow
    */
-  static #defineLazyGetter(module) {
-    const childWindow = window[1];
+  static #defineLazyGetter(module, childWindow) {
     ChromeUtils.defineLazyGetter(childWindow, "PopupNotifications", () => {
       try {
         let shouldSuppress = () => {

--- a/src/second_sidebar/xul/web_panels_browser.mjs
+++ b/src/second_sidebar/xul/web_panels_browser.mjs
@@ -167,7 +167,7 @@ export class WebPanelsBrowser extends Browser {
     this.#listenToFirstDialogAndClose();
 
     // Patch PopupNotifications
-    PopupNotificationsPatcher.patch(this.window.raw);
+    PopupNotificationsPatcher.patch();
 
     // Patch #urlbar-input
     UrlbarInputPatcher.patch();

--- a/src/second_sidebar/xul/web_panels_browser.mjs
+++ b/src/second_sidebar/xul/web_panels_browser.mjs
@@ -167,7 +167,7 @@ export class WebPanelsBrowser extends Browser {
     this.#listenToFirstDialogAndClose();
 
     // Patch PopupNotifications
-    PopupNotificationsPatcher.patch();
+    PopupNotificationsPatcher.patch(this.window.raw);
 
     // Patch #urlbar-input
     UrlbarInputPatcher.patch();
@@ -280,8 +280,10 @@ export class WebPanelsBrowser extends Browser {
    */
   activeWebPanelContains(element) {
     const webPanelTab = this.getActiveWebPanelTab();
+    // Permission buttons can be detached before the click reaches the outer
+    // window. Their owner document still identifies them as panel chrome.
     return (
-      this.window.documentElement?.contains(element) ||
+      this.window.document === element.ownerDocument ||
       webPanelTab.linkedBrowser.contentDocument === element.ownerDocument
     );
   }


### PR DESCRIPTION
Choosing Allow or Block in a web panel's permission prompt also closes the floating web panel when Always on top is disabled. Firefox removes the notification before the click reaches the outer window, so the detached button fails the DOM containment check and is treated as an outside click.

Identify panel chrome through the button's owner document, which remains available after removal. This keeps the web panel open after a permission action and preserves dismissal on ordinary outside clicks.

Related to #193. The original report of unresponsive permission buttons has not been reproduced; this PR addresses the confirmed panel-closing behavior.

Validation:

- Firefox 155.0.1 on Windows in an isolated headless profile: reproduced closing before the change for both Allow and Block; verified their callbacks run, the prompt is removed, the panel stays open after the change, and outside clicks still close it. No FSS console errors.
- ESLint, Prettier on the changed file, and `git diff --check` pass.
