### PR TITLE
fix: add URL validation in icons.mjs

### DIFF
--- a/src/second_sidebar/utils/icons.mjs
+++ b/src/second_sidebar/utils/icons.mjs
@@ -25,6 +25,23 @@ const PREDEFINED_ICONS = {
 
 export const FALLBACK_ICON = "chrome://global/skin/icons/defaultFavicon.svg";
 
+// Hosts pointing at loopback, link-local (incl. cloud metadata) or private
+// network ranges must never be reachable from a user-supplied web panel URL.
+const UNSAFE_HOST_PATTERN =
+  /^(localhost|127\.|10\.|172\.(1[6-9]|2\d|3[01])\.|192\.168\.|169\.254\.|0\.0\.0\.0|\[?::1\]?)/i;
+
+/**
+ *
+ * @param {import("../wrappers/net_utils.mjs").URI} uri
+ * @returns {boolean}
+ */
+function isSafeIconURI(uri) {
+  return (
+    (uri.scheme === "http" || uri.scheme === "https") &&
+    !UNSAFE_HOST_PATTERN.test(uri.host)
+  );
+}
+
 /**
  *
  * @param {string} url
@@ -35,6 +52,11 @@ export function fetchIconURL(url) {
     const uri = NetUtilWrapper.newURI(url);
     if (uri.specIgnoringRef in PREDEFINED_ICONS) {
       resolve(PREDEFINED_ICONS[uri.specIgnoringRef]);
+    }
+
+    if (!isSafeIconURI(uri)) {
+      resolve(FALLBACK_ICON);
+      return;
     }
 
     FaviconsWrapper.setDefaultIconURIPreferredSize(32);


### PR DESCRIPTION
## Summary
Fix high severity security issue in `src/second_sidebar/utils/icons.mjs`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `src/second_sidebar/utils/icons.mjs:35` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-918 |

**Description**: The fetchIconURL function fetches URLs derived from user input without validation. This allows Server-Side Request Forgery (SSRF) attacks where an attacker can make the extension request internal network resources, cloud metadata endpoints, or other restricted URLs.

## Evidence

**Exploitation scenario**: An attacker enters a malicious URL in the web panel URL field (e.g., http://169.254.169.254/latest/meta-data for AWS metadata, http://localhost:8080/admin for internal services).

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `src/second_sidebar/utils/icons.mjs`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->
